### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#SpriteKit-Easing
+# SpriteKit-Easing
 
-###Better Easing for SpriteKit!
+### Better Easing for SpriteKit!
 
 SpriteKit by default uses the easing curve built by Apple into iOS. While this is an awesome curve to use for UI and more traditional mobile apps game development demands more than 2 functions. The goal of this library is to port a set of standard easing functions into the SpriteKit framework as actions.
 
@@ -18,7 +18,7 @@ SpriteKit-Easing contains the following easing functions:
 * Back 
 * Bounce 
 
-##Usage
+## Usage
 The library can directly interact with SKNodes or any Float or Point (for greater compatiblity).
 
 The SKEasing functions generate an action that performs the ease. You can then use / control the action in the same manner you would for any other action in SpriteKit
@@ -40,6 +40,6 @@ SKAction* action = [SKEase MoveToWithNode:node EaseFunction:CurveTypeSine Mode:E
 // Those add a setter that can be used to update a variable of your choice as the action updates
 ```
 
-####More to come... stay tuned...
+#### More to come... stay tuned...
 
 Thanks to [AHEasing](https://github.com/warrenm/AHEasing) for helping me make sense of this easing nonsense!


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
